### PR TITLE
Add RPM .spec file and make evolution optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,7 @@ ltmain.sh
 missing
 .deps
 .libs
+.dirstamp
+protobuf/*.pb-c.c
+protobuf/*.pb-c.h
 /m4/

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,13 +33,13 @@ CHIME_SRCS =	chime/chime-connection.c chime/chime-connection.h \
 noinst_LTLIBRARIES = libchime.la
 
 libchime_la_SOURCES = $(CHIME_SRCS) $(WEBSOCKET_SRCS) $(PROTOBUF_SRCS)
-libchime_la_CFLAGS = $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(PROTOBUF_CFLAGS) $(MARKDOWN_CFLAGS) $(GSTREAMER_CFLAGS) $(GNUTLS_CFLAGS) -Ichime
-libchime_la_LIBADD = $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(PROTOBUF_LIBS) $(MARKDOWN_LIBS) $(GSTREAMER_LIBS) $(GNUTLS_LIBS)
+libchime_la_CFLAGS = $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(PROTOBUF_CFLAGS) $(GSTREAMER_CFLAGS) $(GNUTLS_CFLAGS) -Ichime
+libchime_la_LIBADD = $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(PROTOBUF_LIBS) $(GSTREAMER_LIBS) $(GNUTLS_LIBS)
 libchime_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libchimeprpl_la_SOURCES = $(PRPL_SRCS) $(LOGIN_SRCS)
-libchimeprpl_la_CFLAGS = $(PURPLE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(MARKDOWN_CFLAGS) $(GSTREAMER_CFLAGS) -Ichime -Iprpl
-libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(MARKDOWN_LIBS) $(GSTREAMER_LIBS) libchime.la
+libchimeprpl_la_CFLAGS = $(PURPLE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(GSTREAMER_CFLAGS) -Ichime -Iprpl
+libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(GSTREAMER_LIBS) libchime.la
 libchimeprpl_la_LDFLAGS = -module -avoid-version -no-undefined
 
 POTFILES = $(libchime_la_SOURCES) $(libchimeprpl_la_SOURCES)

--- a/configure.ac
+++ b/configure.ac
@@ -73,16 +73,22 @@ if test "$PROTOC" = ""; then
    AC_MSG_ERROR([protoc-c could not be found. Try installing protobuf-c-compiler])
 fi
 
-build_evoplugin=
-PKG_CHECK_MODULES(EVOLUTION, [evolution-calendar-3.0 evolution-shell-3.0 evolution-data-server-1.2 libebook-1.2 libecal-1.2],
-		  [build_evoplugin=yes
-		   if $PKG_CONFIG --atleast-version 3.20 evolution-shell-3.0; then
-		      AC_DEFINE(EVO_HAS_E_COMP_EDITOR, 1, [Since 3.20])
-		   fi
-		   evomoddir="$($PKG_CONFIG --variable=moduledir evolution-shell-3.0)"
-		   AC_SUBST(evomoddir, ${evomoddir})],
-		  [:]);
-AM_CONDITIONAL(BUILD_EVOPLUGIN, [ test "$build_evoplugin" = "yes" ])
+AC_ARG_WITH([evolution],
+            [AS_HELP_STRING([--without-evolution],
+              [Disable evolution plugin])],
+            [with_evolution=no])
+
+AS_IF([test "x$with_evolution" != xno],
+      [PKG_CHECK_MODULES(EVOLUTION, [evolution-calendar-3.0 evolution-shell-3.0 evolution-data-server-1.2 libebook-1.2 libecal-1.2],
+	[with_evolution=yes
+	 if $PKG_CONFIG --atleast-version 3.20 evolution-shell-3.0; then
+	    AC_DEFINE(EVO_HAS_E_COMP_EDITOR, 1, [Since 3.20])
+	 fi
+	 evomoddir="$($PKG_CONFIG --variable=moduledir evolution-shell-3.0)"
+	 AC_SUBST(evomoddir, ${evomoddir})],
+	[:])])
+
+AM_CONDITIONAL(BUILD_EVOPLUGIN, [ test "$with_evolution" = "yes" ])
 
 fsplugindir="$($PKG_CONFIG --variable=pluginsdir farstream-0.2)"
 AC_SUBST(fsplugindir, ${fsplugindir})

--- a/configure.ac
+++ b/configure.ac
@@ -58,17 +58,6 @@ PKG_CHECK_MODULES(SOUP, [libsoup-2.4 >= 2.50])
 if $PKG_CONFIG --atleast-version 2.59 libsoup-2.4; then
    AC_DEFINE(USE_LIBSOUP_WEBSOCKETS, 1, [Use libsoup websockets])
 fi
-PKG_CHECK_MODULES(MARKDOWN, [libmarkdown], [],
-		  [oldLIBS="$LIBS"
-		   LIBS="$LIBS -lmarkdown"
-		   AC_MSG_CHECKING([for libmarkdown without pkg-config])
-		   AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <mkdio.h>],[mkd_initialize();])],
-				  [AC_MSG_RESULT(yes)
-				   AC_SUBST([MARKDOWN_LIBS], ["-lmarkdown"])
-				   AC_SUBST([MARKDOWN_CFLAGS], [])],
-				  [AC_MSG_RESULT(no)
-				   AC_ERROR([Could not build against libmarkdown])])
-		   LIBS="$oldLIBS"])
 
 gstplugindir="$($PKG_CONFIG --variable=pluginsdir gstreamer-1.0)"
 AC_SUBST(gstplugindir, ${gstplugindir})

--- a/fs-app-transmitter/Makefile.am
+++ b/fs-app-transmitter/Makefile.am
@@ -8,6 +8,3 @@ libapp_transmitter_la_SOURCES = fs-app-stream-transmitter.c fs-app-stream-transm
 					fs-app-transmitter.c  fs-app-transmitter.h
 
 libapp_transmitter_la_LDFLAGS = -module -avoid-version -no-undefined
-
-libapp_transmitter_la_LIBADD = $(EVOLUTION_LIBS)
-

--- a/pidgin-chime.spec
+++ b/pidgin-chime.spec
@@ -1,0 +1,95 @@
+#%%global commit f4fa0044c2d5f68a056447c990bc1e5c2cdf4ecf
+#%%global gittag v%{version}
+#%%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%bcond_without evolution # with
+
+Name:           pidgin-chime
+Summary:        libpurple / Pidgin protocol plugin for Amazon Chime
+Version:        0.02
+Release:        0%{?dist}
+
+Group:          Applications/Communications
+License:        LGPLv2
+URL:            https://github.com/awslabs/pidgin-chime
+Source0:        %{name}-%{version}.tar.gz
+#Source0:        https://github.com/awslabs/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
+#Source0:        https://github.com/awslabs/%{name}/archive/%{gittag}/%{name}-%{version}.tar.gz
+
+BuildRequires:  pkgconfig(purple) >= 2.4.0
+BuildRequires:  pkgconfig(gnutls) >= 3.2.0
+BuildRequires:  pkgconfig(farstream-0.2)
+BuildRequires:  pkgconfig(gstreamer-1.0)
+BuildRequires:  pkgconfig(gstreamer-app-1.0)
+BuildRequires:  pkgconfig(gstreamer-rtp-1.0)
+BuildRequires:  pkgconfig(opus)
+BuildRequires:  pkgconfig(libprotobuf-c)
+BuildRequires:  pkgconfig(json-glib-1.0)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(libsoup-2.4) >= 2.50
+%if %{with evolution}
+BuildRequires:  pkgconfig(evolution-calendar-3.0)
+BuildRequires:  pkgconfig(evolution-shell-3.0)
+BuildRequires:  pkgconfig(evolution-data-server-1.2)
+BuildRequires:  pkgconfig(libebook-1.2)
+BuildRequires:  pkgconfig(libecal-1.2)
+%endif # with evolution
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  gcc
+BuildRequires:  gettext
+BuildRequires:  libtool
+
+%description
+A libpurple / Pidgin protocol plugin for Amazon Chime.
+
+%if %{with evolution}
+%package -n evolution-chime
+Summary:  Evolution plugin for Amazon Chime
+Group:    Applications/Productivity
+Requires: pidgin-chime = %{version}-%{release}
+
+%description -n evolution-chime
+A plugin for Evolution that allows you to create meetings in Amazon Chime.
+%endif # with evolution
+
+%prep
+%setup -q
+#%%setup -q -n %{name}-%{commit}
+#%%setup -q -n %{name}-%{gittag}
+autoreconf -f -i -Wnone
+
+%build
+%configure \
+%if %{without evolution}
+  --without-evolution \
+%endif # without evolution
+  ;
+make %{?_smp_mflags}
+
+%install
+%make_install
+find %{buildroot} -type f -name "*.la" -delete -print
+%find_lang %{name}
+
+%check
+make %{?_smp_mflags} check
+
+%files -f %{name}.lang
+%defattr(-,root,root,-)
+%doc README TODO
+%license COPYING.LGPL
+%{_datadir}/pixmaps/pidgin/protocols/*/chime.*
+%{_libdir}/farstream-0.2/libapp-transmitter.so
+%{_libdir}/gstreamer-1.0/libgstchime.so
+%{_libdir}/purple-2/libchimeprpl.so
+
+%if %{with evolution}
+%files -n evolution-chime
+%defattr(-,root,root,-)
+%{_libdir}/evolution/modules/module-event-from-template.so
+%endif # with evolution
+
+%changelog
+* Fri Apr 13 2018 Andrew Jorgensen <ajorgens@amazon.com> - 0.02-0
+- Initial packaging.


### PR DESCRIPTION
I've tried to conform with Fedora packaging guidelines, and in other ways prepare for adding the package there and in Amazon Linux 2.

David said we could revert the markdown commit since it's just the library linkage for now.

I've made Evolution optional. It brings in many more dependencies, so it's probably best to keep it optional and in a separate subpackage, but enabled by default.